### PR TITLE
Added checking of header inside the ERG file.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -134,6 +134,11 @@ function read(ergFile: string, infoFile: string) {
     byteOrder: headerBuffer.readUInt8(9),
   };
 
+  // Check format specified in the ERG header. Error if not ERG
+  if (!ergHeader.format.startsWith("CM-ERG")) {
+    throw new Error("Invalid ERG file");
+  }
+
   // process erg records by reading value for each quantity
   let recordBuffer = ergBuffer.slice(16);
   let recordIndex = 0;


### PR DESCRIPTION
<!-- Insert YouTrack link if relevant -->
Contributes to [TD-2182](https://sce.myjetbrains.com/youtrack/agiles/115-26/current?issue=TD-2182)
## Changes

- Adds a format check on the header inside the binary erg file
- The ERG file reader will now throw an error if the format is not `CM-ERG`

## Testing notes
This can be tested by passing a valid erg infofile and an invalid file with the erg extension to the `read` function in the erg file reader.

The following script and files can be used:
[test.zip](https://github.com/IPG-Automotive-UK/erg-file-reader/files/12804217/test.zip)

Extract the zip inside the erg-file-reader folder and run `npx ts-node test.ts`

Check that the erg-file-reader will error with the message: "Invalid ERG file"
## Author checklist before assigning a reviewer

- [x] Reviewed my own code-diff.
- [x] Branch has been run in docker.
- [x] PR assigned to me or an appropriate delegate.
- [x] Relevant labels added to the PR.
- [ ] Appropriate tests have been added.
- [ ] Lint and test workflows pass.
